### PR TITLE
Fix/obstacle inflation

### DIFF
--- a/install/dependencies.rosinstall
+++ b/install/dependencies.rosinstall
@@ -1,3 +1,3 @@
 - git: {local-name: catkin_simple, uri: 'git@github.com:catkin/catkin_simple.git'}
-- git: {local-name: cgal_catkin, uri: 'git@github.com:ethz-asl/cgal_catkin.git', version: feature/4.14}
+- git: {local-name: cgal_catkin, uri: 'git@github.com:ethz-asl/cgal_catkin.git', version: releases/CGAL-4.14.1}
 - git: {local-name: polygon_coverage_planning, uri: 'git@github.com:ethz-asl/polygon_coverage_planning.git'}

--- a/install/dependencies_https.rosinstall
+++ b/install/dependencies_https.rosinstall
@@ -1,3 +1,3 @@
 - git: {local-name: catkin_simple, uri: 'https://github.com/catkin/catkin_simple.git'}
-- git: {local-name: cgal_catkin, uri: 'https://github.com/ethz-asl/cgal_catkin.git', version: feature/4.14}
+- git: {local-name: cgal_catkin, uri: 'https://github.com/ethz-asl/cgal_catkin.git', version: releases/CGAL-4.14.1}
 - git: {local-name: polygon_coverage_planning, uri: 'https://github.com/ethz-asl/polygon_coverage_planning.git'}

--- a/polygon_coverage_geometry/src/offset.cc
+++ b/polygon_coverage_geometry/src/offset.cc
@@ -47,6 +47,8 @@ void computeOffsetPolygon(const PolygonWithHoles& pwh, FT max_offset,
     *offset_polygon = *result.front();
     return;
   } else {
+    ROS_WARN(
+        "Polygon offsetting changes topology. Reducing offsetting distance.");
     result = {boost::make_shared<PolygonWithHoles>(sorted_pwh)};
   }
 

--- a/polygon_coverage_geometry/test/visibility_polygon-test.cpp
+++ b/polygon_coverage_geometry/test/visibility_polygon-test.cpp
@@ -70,13 +70,13 @@ TEST(VisibilityPolygonTest, computeVisibilityPolygon) {
   // Result manually checked.
   vit = visibility_polygon.vertices_begin();
   EXPECT_EQ(static_cast<size_t>(7), visibility_polygon.size());
-  EXPECT_EQ(Point_2(1, 1.25), *vit++);
-  EXPECT_EQ(Point_2(0.5, 1.25), *vit++);
-  EXPECT_EQ(Point_2(0, 2), *vit++);
   EXPECT_EQ(Point_2(0, 0), *vit++);
   EXPECT_EQ(Point_2(2, 0), *vit++);
   EXPECT_EQ(Point_2(2, 2), *vit++);
   EXPECT_EQ(Point_2(1, 2), *vit++);
+  EXPECT_EQ(Point_2(1, 1.25), *vit++);
+  EXPECT_EQ(Point_2(0.5, 1.25), *vit++);
+  EXPECT_EQ(Point_2(0, 2), *vit++);
 
   // Query on polygon halfedge.
   query = Point_2(1.0, 0.0);

--- a/polygon_coverage_planners/src/graphs/sweep_plan_graph.cc
+++ b/polygon_coverage_planners/src/graphs/sweep_plan_graph.cc
@@ -77,22 +77,10 @@ bool NodeProperty::isNonOptimal(
 void SweepPlanGraph::offsetPolygonFromWalls() {
   if (settings_.wall_distance <= 0.0) return;
 
-  std::vector<boost::shared_ptr<PolygonWithHoles>> result =
-      CGAL::create_interior_skeleton_and_offset_polygons_with_holes_2(
-          settings_.wall_distance, settings_.polygon);
-
-  ROS_ASSERT(!result.empty());
-  ROS_WARN_COND(
-      result.size() > 1,
-      "Offsetting the polygon by %.2f m from the wall resulted in multiple "
-      "polygons with holes. Only considering the first polygon.",
-      CGAL::to_double(settings_.wall_distance));
-
-  if (result.empty()) {
-    ROS_WARN("No polygon left after offsetting from wall. Cancel offsetting.");
-  } else {
-    settings_.polygon = *(result.front());
-  }
+  PolygonWithHoles temp_poly = settings_.polygon;
+  computeOffsetPolygon(temp_poly, settings_.wall_distance, &settings_.polygon);
+  // Update visibility graph.
+  visibility_graph_ = visibility_graph::VisibilityGraph(settings_.polygon);
 }
 
 bool SweepPlanGraph::create() {

--- a/polygon_coverage_ros/CMakeLists.txt
+++ b/polygon_coverage_ros/CMakeLists.txt
@@ -7,6 +7,7 @@ catkin_simple(ALL_DEPS_REQUIRED)
 add_definitions(-std=c++17)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
+set(CMAKE_BUILD_TYPE Release)
 
 find_package(CGAL QUIET COMPONENTS Core)
 include(${CGAL_USE_FILE})


### PR DESCRIPTION
Fixes https://github.com/ethz-asl/polygon_coverage_planning/issues/26

a) The visibility graph was not recomputed when offsetting the polygon. 
b) The PWH was not sorted correctly before being passed to `create_interior_skeleton_and_offset_polygons_with_holes_2`. Replacing the direct method call with `polygon_coverage_geometry` method for better consistency with shortest path planning node.