### PR TITLE
Add RVIZ satellite example.

### DIFF
--- a/polygon_coverage_ros/cfg/rviz/coverage_planner_satellite.rviz
+++ b/polygon_coverage_ros/cfg/rviz/coverage_planner_satellite.rviz
@@ -1,0 +1,178 @@
+Panels:
+  - Class: rviz/Displays
+    Help Height: 81
+    Name: Displays
+    Property Tree Widget:
+      Expanded:
+        - /Global Options1
+        - /Status1
+        - /Grid1
+        - /TF1
+        - /TF1/Frames1
+        - /TF1/Tree1
+        - /MarkerArray1
+        - /MarkerArray1/Namespaces1
+        - /AerialMapDisplay1
+      Splitter Ratio: 0.4285714328289032
+    Tree Height: 799
+  - Class: rviz/Selection
+    Name: Selection
+  - Class: rviz/Tool Properties
+    Expanded:
+      - /2D Pose Estimate1
+      - /2D Nav Goal1
+      - /Publish Point1
+    Name: Tool Properties
+    Splitter Ratio: 0.5886790156364441
+  - Class: rviz/Views
+    Expanded:
+      - /Current View1
+    Name: Views
+    Splitter Ratio: 0.5
+  - Class: rviz/Time
+    Experimental: false
+    Name: Time
+    SyncMode: 0
+    SyncSource: ""
+Preferences:
+  PromptSaveOnExit: true
+Toolbars:
+  toolButtonStyle: 2
+Visualization Manager:
+  Class: ""
+  Displays:
+    - Alpha: 0.5
+      Cell Size: 1
+      Class: rviz/Grid
+      Color: 160; 160; 164
+      Enabled: true
+      Line Style:
+        Line Width: 0.029999999329447746
+        Value: Lines
+      Name: Grid
+      Normal Cell Count: 0
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Plane: XY
+      Plane Cell Count: 200
+      Reference Frame: <Fixed Frame>
+      Value: true
+    - Class: rviz/TF
+      Enabled: true
+      Frame Timeout: 15
+      Frames:
+        All Enabled: false
+      Marker Scale: 1
+      Name: TF
+      Show Arrows: true
+      Show Axes: true
+      Show Names: true
+      Tree:
+        {}
+      Update Interval: 0
+      Value: true
+    - Class: rviz/MarkerArray
+      Enabled: true
+      Marker Topic: /coverage_planner/path_markers
+      Name: MarkerArray
+      Namespaces:
+        "": true
+        decomposition_polygon_0hull: true
+        decomposition_polygon_10hull: true
+        decomposition_polygon_11hull: true
+        decomposition_polygon_12hull: true
+        decomposition_polygon_13hull: true
+        decomposition_polygon_1hull: true
+        decomposition_polygon_2hull: true
+        decomposition_polygon_3hull: true
+        decomposition_polygon_4hull: true
+        decomposition_polygon_5hull: true
+        decomposition_polygon_6hull: true
+        decomposition_polygon_7hull: true
+        decomposition_polygon_8hull: true
+        decomposition_polygon_9hull: true
+        points_end: true
+        points_end_text: true
+        points_start: true
+        polygonhole_mesh_0: true
+        polygonhole_mesh_1: true
+        polygonhole_mesh_2: true
+        polygonhull: true
+        vertices_and_strip: true
+      Queue Size: 100
+      Value: true
+    - Alpha: 0.699999988079071
+      Blocks: 4
+      Class: rviz_plugins/AerialMapDisplay
+      Draw Behind: false
+      Enabled: true
+      Frame Convention: XYZ -> ENU
+      Name: AerialMapDisplay
+      Object URI: https://mt1.google.com/vt/lyrs=s&x={x}&y={y}&z={z}
+      Topic: /rviz_satellite/home_gps
+      Value: true
+      Zoom: 20
+  Enabled: true
+  Global Options:
+    Background Color: 255; 255; 255
+    Default Light: true
+    Fixed Frame: map
+    Frame Rate: 30
+  Name: root
+  Tools:
+    - Class: rviz/Interact
+      Hide Inactive Objects: true
+    - Class: rviz/MoveCamera
+    - Class: rviz/Select
+    - Class: rviz/FocusCamera
+    - Class: rviz/Measure
+    - Class: rviz/SetInitialPose
+      Theta std deviation: 0.2617993950843811
+      Topic: /initialpose
+      X std deviation: 0.5
+      Y std deviation: 0.5
+    - Class: rviz/SetGoal
+      Topic: /move_base_simple/goal
+    - Class: rviz/PublishPoint
+      Single click: true
+      Topic: /clicked_point
+    - Class: rviz_polygon_tool/PolygonSelection
+  Value: true
+  Views:
+    Current:
+      Angle: 0
+      Class: rviz/TopDownOrtho
+      Enable Stereo Rendering:
+        Stereo Eye Separation: 0.05999999865889549
+        Stereo Focal Distance: 1
+        Swap Stereo Eyes: false
+        Value: false
+      Invert Z Axis: false
+      Name: Current View
+      Near Clip Distance: 0.009999999776482582
+      Scale: 8.818445205688477
+      Target Frame: <Fixed Frame>
+      Value: TopDownOrtho (rviz)
+      X: 7.112266540527344
+      Y: 28.676179885864258
+    Saved: ~
+Window Geometry:
+  Displays:
+    collapsed: true
+  Height: 1031
+  Hide Left Dock: true
+  Hide Right Dock: true
+  QMainWindow State: 000000ff00000000fd0000000400000000000001a5000003adfc020000000afb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073000000003d000003ad000000c900fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb0000000a0049006d0061006700650000000250000001990000000000000000fb0000000a0049006d00610067006500000002cd0000011c0000000000000000000000010000010f000003adfc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073000000003d000003ad000000a400fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000007800000003efc0100000002fb0000000800540069006d00650000000000000007800000025600fffffffb0000000800540069006d0065010000000000000450000000000000000000000780000003ad00000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  Selection:
+    collapsed: false
+  Time:
+    collapsed: false
+  Tool Properties:
+    collapsed: false
+  Views:
+    collapsed: true
+  Width: 1920
+  X: 0
+  Y: 25

--- a/polygon_coverage_ros/cfg/rviz/home.gps
+++ b/polygon_coverage_ros/cfg/rviz/home.gps
@@ -1,0 +1,14 @@
+header:
+  seq: 28
+  stamp:
+    secs: 1550757135
+    nsecs: 803256034
+  frame_id: "piksi"
+status:
+  status: 2
+  service: 1
+latitude: 47.405298
+longitude: 8.638944
+altitude: 0.0
+position_covariance: [0.0049, 0.0, 0.0, 0.0, 0.0049, 0.0, 0.0, 0.0, 0.01]
+position_covariance_type: 1

--- a/polygon_coverage_ros/launch/coverage_planner.launch
+++ b/polygon_coverage_ros/launch/coverage_planner.launch
@@ -1,5 +1,7 @@
 <launch>
-  <node name="rviz" pkg="rviz" type="rviz" output="log" args="-d $(find polygon_coverage_ros)/cfg/rviz/coverage_planner.rviz"/>
+  <arg name="rviz_config" default="$(find polygon_coverage_ros)/cfg/rviz/coverage_planner.rviz"/>
+
+  <node name="rviz" pkg="rviz" type="rviz" output="log" args="-d $(arg rviz_config)"/>
 
   <node name="coverage_planner" pkg="polygon_coverage_ros" type="coverage_planner" output="screen" clear_params="true">
 

--- a/polygon_coverage_ros/launch/coverage_planner_satellite.launch
+++ b/polygon_coverage_ros/launch/coverage_planner_satellite.launch
@@ -1,0 +1,10 @@
+<launch>
+  <!-- Coverage planner. -->
+  <include file="$(find polygon_coverage_ros)/launch/coverage_planner.launch">
+    <arg name="rviz_config" value="$(find polygon_coverage_ros)/cfg/rviz/coverage_planner_satellite.rviz" /> 
+  </include>
+
+  <!-- Send a static GPS fix to center the map. Edit latitude and longitude in cfg/rviz/home.gps to use your own position. -->
+  <node pkg="rostopic" type="rostopic" name="home_gps_fix" args="pub /rviz_satellite/home_gps sensor_msgs/NavSatFix --latch --file=$(find polygon_coverage_ros)/cfg/rviz/home.gps" output="screen"/>
+
+</launch>


### PR DESCRIPTION
This PR adds a launch file to start the coverage planner with an underlying satellite map.

![rviz_screenshot_2020_03_06-10_37_31](https://user-images.githubusercontent.com/11293852/76071560-c3a00a00-5f96-11ea-9c77-08bf82b2187a.png)

![rviz_screenshot_2020_03_06-10_37_57](https://user-images.githubusercontent.com/11293852/76071572-c7339100-5f96-11ea-8c3c-4686eb0c6dd1.png)
