### PR TITLE
Add github actions workflow for build tests

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -1,0 +1,54 @@
+
+name: Build Test
+on:
+  push:
+    branches:
+    - 'master'
+  pull_request:
+    branches:
+    - '*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {rosdistro: 'noetic', container: 'ros:noetic-ros-base-focal'}
+    container: ${{ matrix.config.container }}
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        token: ${{ secrets.ACCESS_TOKEN }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Install catkin-tools on Noetic
+      run: |
+        apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
+        apt update && apt install -y python3-pip
+        pip3 install osrf-pycommon
+        apt update && apt install -y python3-wstool python3-catkin-tools
+    - name: Install Dependencies
+      run: |
+        $GITHUB_WORKSPACE/install/prepare-jenkins-slave.sh
+      shell: bash
+    - name: Build test
+      working-directory: 
+      env:
+        DEBIAN_FRONTEND: noninteractive
+      run: |
+        apt update
+        apt install -y autoconf libtool git qt5-default
+        mkdir -p $HOME/catkin_ws/src;
+        cd $HOME/catkin_ws
+        catkin init
+        catkin config --extend "/opt/ros/${{matrix.config.rosdistro}}"
+        catkin config --merge-devel
+        cd $HOME/catkin_ws/src
+        ln -s $GITHUB_WORKSPACE
+        cd $HOME/catkin_ws
+        rosdep update
+        rosdep install --from-paths src --ignore-src -y --rosdistro ${{matrix.config.rosdistro}}
+        catkin config --cmake-args -DCMAKE_BUILD_TYPE=Release
+        catkin build -j$(nproc) -l$(nproc)
+      shell: bash

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -1,4 +1,3 @@
-
 name: Build Test
 on:
   push:
@@ -10,7 +9,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux]
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
**Problem Description**
This PR adds a workflow using [GitHub actions](https://github.com/features/actions) to run simple build tests

This provides an alternative to the existing jenkins server, but runs without the infrastructure that is required for jenkins to run.

**Testing**
- Tested on my personal fork: https://github.com/Jaeyoung-Lim/polygon_coverage_planning/pull/1
- Log: https://github.com/Jaeyoung-Lim/polygon_coverage_planning/actions/runs/3118718822/jobs/5058191952


