### PR TITLE
Add cgal dependency to package.xml

### DIFF
--- a/polygon_coverage_geometry/package.xml
+++ b/polygon_coverage_geometry/package.xml
@@ -14,6 +14,7 @@
 
   <depend>rosconsole</depend>
   <depend>roslib</depend>
+  <depend>cgal</depend>
   <depend>rosunit</depend>
   <depend>polygon_coverage_solvers</depend>
 

--- a/polygon_coverage_planners/package.xml
+++ b/polygon_coverage_planners/package.xml
@@ -14,6 +14,7 @@
 
   <depend>rosconsole</depend>
   <depend>roslib</depend>
+  <depend>cgal</depend>
 
   <depend>polygon_coverage_solvers</depend>
   <depend>polygon_coverage_geometry</depend>

--- a/polygon_coverage_ros/package.xml
+++ b/polygon_coverage_ros/package.xml
@@ -13,6 +13,7 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <depend>roscpp</depend>
+  <depend>cgal</depend>
 
   <depend>nav_msgs</depend>
   <depend>geometry_msgs</depend>


### PR DESCRIPTION
Allows installing libcgal-dev with rosdep install.