### PR TITLE
Switch github actions to github hosted

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    runs-on: [self-hosted, linux]
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
**Problem Description**
The self hosted github action seems to segfault in gcc.

Wondering if this is a memory problem and switched to github hosted to see if it solves the problem.